### PR TITLE
Add bottom padding to last item so that all items can be visible even if UI scroll is enabled

### DIFF
--- a/app/src/main/java/jp/ddo/hotmist/unicodepad/LockableScrollView.kt
+++ b/app/src/main/java/jp/ddo/hotmist/unicodepad/LockableScrollView.kt
@@ -61,6 +61,7 @@ class LockableScrollView : ScrollView {
         if (!over) scrollTo(0, 0)
         lockView.layoutParams.height = if (over) height else height - lockView.top
         lockView.requestLayout()
+        adapter.onSizeChanged(if (over) lockView.top else 0)
     }
 
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
@@ -70,6 +71,7 @@ class LockableScrollView : ScrollView {
             lockView?.let {
                 it.layoutParams.height = if (over) h else h - it.top
                 it.requestLayout()
+                adapter.onSizeChanged(if (over) it.top else 0)
                 it.post { scrollTo(0, pos) }
             }
         }

--- a/app/src/main/java/jp/ddo/hotmist/unicodepad/PageAdapter.kt
+++ b/app/src/main/java/jp/ddo/hotmist/unicodepad/PageAdapter.kt
@@ -245,6 +245,12 @@ class PageAdapter(private val activity: UnicodeActivity, private val pref: Share
         for (i in 0 until MAX_VIEWS) views[i]?.invalidateViews()
     }
 
+    fun onSizeChanged(top: Int) {
+        adapters.forEach {
+            it.lastPadding = top
+        }
+    }
+
     companion object {
         var column = 8
         private const val MAX_VIEWS: Int = 6

--- a/app/src/main/java/jp/ddo/hotmist/unicodepad/UnicodeActivity.kt
+++ b/app/src/main/java/jp/ddo/hotmist/unicodepad/UnicodeActivity.kt
@@ -186,7 +186,7 @@ class UnicodeActivity : AppCompatActivity() {
             pager.adapter = it
             scroll.setAdapter(it)
         }
-        scroll.setLockView(pager, Integer.valueOf(pref.getString("scroll", null)?.toIntOrNull() ?: 1) + (if (resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) 1 else 0) > 1)
+        scroll.setLockView(pager, (pref.getString("scroll", null)?.toIntOrNull() ?: 1) + (if (resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) 1 else 0) > 1)
         cm = getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
         disableime = pref.getBoolean("ime", true)
         pager.setCurrentItem(min(pref.getInt("page", 1), adpPage.count - 1), false)

--- a/app/src/main/java/jp/ddo/hotmist/unicodepad/UnicodeAdapter.kt
+++ b/app/src/main/java/jp/ddo/hotmist/unicodepad/UnicodeAdapter.kt
@@ -27,6 +27,7 @@ import com.mobeta.android.dslv.DragSortListView.RemoveListener
 abstract class UnicodeAdapter(protected val activity: Activity, private val db: NameDatabase, var single: Boolean) : BaseAdapter() {
     private var typeface: Typeface? = null
     protected var view: AbsListView? = null
+    internal var lastPadding: Int = 0
     open fun name(): Int {
         return 0
     }
@@ -94,10 +95,11 @@ abstract class UnicodeAdapter(protected val activity: Activity, private val db: 
                         (linearLayout.getChildAt(1) as TextView).text = db[getItemString(i), "name"]
                     }
                 }
+                it.setPadding(0, 0, 0, if (i == this.count - 1) lastPadding else 0)
             }
         } else {
             (view as CharacterView? ?: CharacterView(activity, null, android.R.attr.textAppearanceLarge)).also {
-                it.setPadding(padding, padding, padding, padding)
+                it.setPadding(padding, padding, padding, padding + if (i == this.count - 1) lastPadding else 0)
                 it.setTextSize(fontsize)
                 it.shrinkWidth(shrink)
                 it.setTypeface(typeface)


### PR DESCRIPTION
The last few rows of lists might be hidden because of UI scroll.
Users often don't notice UI scroll is enabled.
This commit adds extra padding to the last item of lists and all items can be visible even if UI scroll is enabled and not scrolled.