### PR TITLE
added International English (values-b+en+001)

### DIFF
--- a/app/src/main/res/values-b+en+001/strings.xml
+++ b/app/src/main/res/values-b+en+001/strings.xml
@@ -1,0 +1,7 @@
+<resources>
+	<string name="favorite">Favourite</string>
+	<string name="guide_content_3">You can use variety of pads, including emoji, find, and favourite.</string>
+	<string name="guide_content_5">You can customise behaviour and appearance of the app. You can revisit this tutorial from the setting as well.</string>
+	<string name="behaviour">Behaviour</string>
+	<string name="data_favorite">Favourite (%1$d)</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -388,7 +388,7 @@
 
 	<string name="general">General</string>
 	<string name="appearance">Appearance</string>
-	<string name="behaviour">Behaviour</string>
+	<string name="behaviour">Behavior</string>
 	<string name="textsize_desc">Text size of edit box</string>
 	<string name="column_desc">Columns in grid</string>
 	<string name="columnl_desc">Columns in grid (landscape)</string>


### PR DESCRIPTION
International English is added to Android using code `values-b+en+001` where all locales of English that does not use US English will read from, after reading from their own locale first. More information about it here: https://developer.android.com/guide/topics/resources/multilingual-support

So a user using `en_GB`, `en_AU` and such, Android will first look for the specific locale, then look for `values-b+en+001` to finally default to `values` which it will pretend is `values-en`. Locale `en_US` will not look for `values-b+en+001` and instead default directly to `values`.

This will change the words "favorite" and "behavior" to "favourite" and "behaviour" to just add a little more polish to the app. All other string will use the default English strings.

One change in the original string to change "behaviour" to "behavior" for consistency.

When testing, en_US, en_PR should use "favorite" and en_CA, en_ZA should use "favourite".