### PR TITLE
added Canadian English (en-rCA)

### DIFF
--- a/app/src/main/res/values-b+en+001/strings.xml
+++ b/app/src/main/res/values-b+en+001/strings.xml
@@ -1,0 +1,7 @@
+<resources>
+	<string name="favorite">Favourite</string>
+	<string name="guide_content_3">You can use variety of pads, including emoji, find, and favourite.</string>
+	<string name="guide_content_5">You can customise behaviour and appearance of the app. You can revisit this tutorial from the setting as well.</string>
+	<string name="behaviour">Behaviour</string>
+	<string name="data_favorite">Favourite (%1$d)</string>
+</resources>

--- a/app/src/main/res/values-en-rCA/strings.xml
+++ b/app/src/main/res/values-en-rCA/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+	<string name="guide_content_5">You can customize behaviour and appearance of the app. You can revisit this tutorial from the setting as well.</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -388,7 +388,7 @@
 
 	<string name="general">General</string>
 	<string name="appearance">Appearance</string>
-	<string name="behaviour">Behaviour</string>
+	<string name="behaviour">Behavior</string>
 	<string name="textsize_desc">Text size of edit box</string>
 	<string name="column_desc">Columns in grid</string>
 	<string name="columnl_desc">Columns in grid (landscape)</string>


### PR DESCRIPTION
This is just another expansion of proper English for all locales. This will change the word that was changed to "customise" in International English back to "customize" for Canadian English, while keeping "favourite" and "behaviour".

en_US -> customize behavior
en_CA -> customize behaviour
en_IE -> customise behaviour