### PR TITLE
Update emoji2 to 1.6.0-beta01 to support emoji 16.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     implementation "androidx.core:core-ktx:$kotlin_version"
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'androidx.emoji2:emoji2-bundled:1.5.0'
+    implementation 'androidx.emoji2:emoji2-bundled:1.6.0-beta01'
     implementation 'androidx.preference:preference-ktx:1.2.1'
     implementation 'com.github.woxthebox:draglistview:1.7.3'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"


### PR DESCRIPTION
Open when https://issuetracker.google.com/issues/432864541 is resolved